### PR TITLE
Add simple Expo budget tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Node dependencies
+app/node_modules
+
+# Expo
+app/.expo
+app/.expo/*
+app/dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Food Budget Tracking App
+
+This repository contains a minimal React Native (Expo) application to log daily meals and track a 14‑day food budget.
+
+## Running
+
+Install dependencies with `npm install` inside the `app` directory and then start Expo:
+
+```bash
+cd app
+npm install
+npm start
+```
+
+You can run on web with `npm run web` or on a device using the Expo Go app.
+
+## Features
+
+* Log four meal categories: **vegan**, **vegetarian**, **small meat** and **big meat**.
+* Meal data is stored locally using `AsyncStorage`.
+* Budgets are tracked over the last 14 days.
+  * Two vegetarian meals count as **one meat** plus **one vegan** meal.
+  * A big meat meal costs **two meat** meals.
+* The home screen displays remaining meat and vegan meals in the current budget window.

--- a/app/App.js
+++ b/app/App.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const MEAT_BUDGET = 7;
+const VEGAN_BUDGET = 7;
+const STORAGE_KEY = 'MEALS';
+
+function mealCost(type) {
+  switch (type) {
+    case 'bigMeat':
+      return { meat: 2, vegan: 0 };
+    case 'smallMeat':
+      return { meat: 1, vegan: 0 };
+    case 'vegetarian':
+      return { meat: 0.5, vegan: 0.5 };
+    case 'vegan':
+      return { meat: 0, vegan: 1 };
+    default:
+      return { meat: 0, vegan: 0 };
+  }
+}
+
+export default function App() {
+  const [meals, setMeals] = useState([]);
+  const [budget, setBudget] = useState({ meat: MEAT_BUDGET, vegan: VEGAN_BUDGET });
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await AsyncStorage.getItem(STORAGE_KEY);
+        if (data) setMeals(JSON.parse(data));
+      } catch (e) {
+        console.log('load error', e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    updateBudget();
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(meals)).catch(e => console.log('save error', e));
+  }, [meals]);
+
+  const addMeal = type => {
+    setMeals([...meals, { type, date: new Date().toISOString() }]);
+  };
+
+  const updateBudget = () => {
+    const now = Date.now();
+    const twoWeeks = 14 * 24 * 60 * 60 * 1000;
+    const recent = meals.filter(m => new Date(m.date).getTime() > now - twoWeeks);
+    const used = recent.reduce((acc, m) => {
+      const cost = mealCost(m.type);
+      return { meat: acc.meat + cost.meat, vegan: acc.vegan + cost.vegan };
+    }, { meat: 0, vegan: 0 });
+    setBudget({
+      meat: Math.max(0, MEAT_BUDGET - used.meat),
+      vegan: Math.max(0, VEGAN_BUDGET - used.vegan)
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Remaining Budget</Text>
+      <Text style={styles.budget}>{budget.meat.toFixed(1)} meat meals</Text>
+      <Text style={styles.budget}>{budget.vegan.toFixed(1)} vegan meals</Text>
+      <View style={styles.buttons}>
+        <Button title="Vegan" onPress={() => addMeal('vegan')} />
+        <Button title="Vegetarian" onPress={() => addMeal('vegetarian')} />
+        <Button title="Small Meat" onPress={() => addMeal('smallMeat')} />
+        <Button title="Big Meat" onPress={() => addMeal('bigMeat')} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  header: { fontSize: 24, marginBottom: 16 },
+  budget: { fontSize: 18, marginBottom: 4 },
+  buttons: { marginTop: 20, height: 240, justifyContent: 'space-between' }
+});

--- a/app/app.json
+++ b/app/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "FoodBudgetApp",
+    "slug": "food-budget-app",
+    "version": "1.0.0",
+    "platforms": ["ios", "android", "web"],
+    "sdkVersion": "49.0.0",
+    "orientation": "portrait"
+  }
+}

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = function(api) {
+  api.cache(true);
+  return { presets: ['babel-preset-expo'] };
+};

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "food_budget_app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "web": "expo start --web",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-native-async-storage/async-storage": "^1.17.11"
+  }
+}


### PR DESCRIPTION
## Summary
- create minimal Expo app skeleton in `app/`
- implement local meal logging and budget calculation
- document setup and features

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ce6a96d2c8332aba7fe338bf414c9